### PR TITLE
Draft: Add extra call signature to `userProfile` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-auth-microsoft",
+  "name": "@speechmatics/remix-auth-microsoft",
   "version": "2.0.1",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
     });
   }
 
+  protected async userProfile(accessToken: string, extraParams: MicrosoftExtraParams): Promise<MicrosoftProfile>;
   protected async userProfile(accessToken: string): Promise<MicrosoftProfile> {
     const response = await fetch(this.userInfoURL, {
       headers: {


### PR DESCRIPTION
The `MicrosoftStrategy` class overrides the `userProfile` method of the `OAuth2Strategy` class in such a way that the `extraParams` argument is ignored.

While this argument is not used in this implementation, removing it means that any subclasses of `MicrosoftStrategy` won't be able to leverage this second argument, which may be necessary in cases where the id_token needs to be read.