### PR TITLE
Add call signature with extraParams to userProfile override

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
     });
   }
 
+  protected async userProfile(accessToken: string, extraParams: MicrosoftExtraParams): Promise<MicrosoftProfile>;
   protected async userProfile(accessToken: string): Promise<MicrosoftProfile> {
     const response = await fetch(this.userInfoURL, {
       headers: {


### PR DESCRIPTION
The MicrosoftStrategy class overrides the userProfile method of the OAuth2Strategy class in such a way that the extraParams argument is ignored.

While this argument is not used in this implementation, removing it means that any subclasses of MicrosoftStrategy won't be able to leverage this second argument, which may be necessary in cases where the id_token needs to be read.