### PR TITLE
Allow configuration for custom AD B2C policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "remix-auth-microsoft",
+  "name": "@speechmatics/remix-auth-microsoft",
   "version": "2.0.1",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "types": "./build/index.d.ts",
   "scripts": {
     "build": "tsc --project tsconfig.json",
+    "prepare": "npm run build",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "lint": "eslint --ext .ts,.tsx src/",
     "test": "jest --config=config/jest.config.ts --passWithNoTests",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@speechmatics/remix-auth-microsoft",
+  "name": "remix-auth-microsoft",
   "version": "2.0.1",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ export interface MicrosoftStrategyOptions {
   scope?: MicrosoftScope[] | string;
   tenantId?: string;
   prompt?: string;
+  domain?: string;
+  policy?: string;
+  userInfoURL?: string;
 }
 
 export interface MicrosoftProfile extends OAuth2Profile {
@@ -61,7 +64,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
 
   scope: string;
   private prompt: string;
-  private userInfoURL = "https://graph.microsoft.com/oidc/userinfo";
+  private userInfoURL: string;
 
   constructor(
     {
@@ -71,6 +74,9 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
       scope,
       prompt,
       tenantId = "common",
+      domain = "login.microsoftonline.com",
+      policy,
+      userInfoURL = "https://graph.microsoft.com/oidc/userinfo",
     }: MicrosoftStrategyOptions,
     verify: StrategyVerifyCallback<
       User,
@@ -82,14 +88,19 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
         clientID: clientId,
         clientSecret,
         callbackURL: redirectUri,
-        authorizationURL: `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`,
-        tokenURL: `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`,
+        authorizationURL: policy
+          ? `https://${domain}/${tenantId}/${policy}/oauth2/v2.0/authorize`
+          : `https://${domain}/${tenantId}/oauth2/v2.0/authorize`,
+        tokenURL: policy
+          ? `https://${domain}/${tenantId}/${policy}/oauth2/v2.0/token`
+          : `https://${domain}/${tenantId}/oauth2/v2.0/token`,
       },
       verify
     );
 
     this.scope = this.getScope(scope);
     this.prompt = prompt ?? "none";
+    this.userInfoURL = userInfoURL;
   }
 
   //Allow users the option to pass a scope string, or typed array

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,6 +122,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
     });
   }
 
+  protected async userProfile(accessToken: string, extraParams: MicrosoftExtraParams): Promise<MicrosoftProfile>;
   protected async userProfile(accessToken: string): Promise<MicrosoftProfile> {
     const response = await fetch(this.userInfoURL, {
       headers: {


### PR DESCRIPTION
This PR enables configuring the following values:

- `domain`: For cases when a custom domain is used instead of `login.microsoftonline.com`
- `policy`: For when multiple policies exist on the same B2C tenant (i.e. when [password-reset custom policy](https://learn.microsoft.com/en-us/azure/active-directory-b2c/add-password-change-policy?pivots=b2c-custom-policy) is in place)
- `userInfoURL` is now also configurable in the constructor, since this URL will also differ from the defaults when using the above options