### PR TITLE
fix: prompt should be optional to avoid interrupting SSO

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
   name = MicrosoftStrategyDefaultName;
 
   scope: string;
-  private prompt: string;
+  private prompt: string | undefined;
   private userInfoURL = "https://graph.microsoft.com/oidc/userinfo";
 
   constructor(
@@ -89,7 +89,7 @@ export class MicrosoftStrategy<User> extends OAuth2Strategy<
     );
 
     this.scope = this.getScope(scope);
-    this.prompt = prompt ?? "none";
+    this.prompt = prompt;
   }
 
   //Allow users the option to pass a scope string, or typed array


### PR DESCRIPTION
This is probably not safe to merge immediately into the 2.x version since it will change the default behavior, but after banging my head against why I couldn't get the "normal" auth flow to work in a downstream fork, I found that prompt is being set to "none" by default.

`prompt` is an optional attribute. Defaulting to "none" prevents the default SSO flow from taking place if the user isn't logged in or hasn't authenticated the app. If it is undefined then the "normal" flow happens: MS figures out if they are logged in and if they have granted consent and handles prompting as needed. 

See: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow

<img width="862" alt="Screenshot 2024-06-16 at 10 39 49 AM" src="https://github.com/speechmatics/remix-auth-microsoft/assets/7569921/e37ef00c-6177-401c-85b7-799a2e7381a0">


For anyone else who runs into this issue, you can override back to the default SSO flow by setting `prompt` to an empty string so the `??` doesn't catch, but that seems pretty clunky.

